### PR TITLE
Fix NullPointerException caused when fired by a non-op user

### DIFF
--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -20,7 +20,7 @@ commands:
       /wild [player] [world] - Teleport randomly this player in given world
       /wild [north/south/east/west] - Teleport randomly in the given direction
       /wild [world] - Teleport randomly in the given world
-    default: true
+    default: false
 
   wildtp:
     description: Admin tasks like reload, manage portals, ...

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -20,6 +20,7 @@ commands:
       /wild [player] [world] - Teleport randomly this player in given world
       /wild [north/south/east/west] - Teleport randomly in the given direction
       /wild [world] - Teleport randomly in the given world
+    default: true
 
   wildtp:
     description: Admin tasks like reload, manage portals, ...
@@ -32,6 +33,7 @@ commands:
       /wildtp link [name] [name]- Link two portals
       /wildtp reload - Reload the plugin configuration
       /wildtp gui - Open the plugin user interface
+    default: op
 
 permissions:
   wild.wildtp:


### PR DESCRIPTION
Resolves NullPointerException fired when people who are not OP fire /wild